### PR TITLE
Modify libzfs-core-sys/build.rs for FreeBSD

### DIFF
--- a/libzfs-core-sys/build.rs
+++ b/libzfs-core-sys/build.rs
@@ -2,6 +2,11 @@ extern crate pkg_config;
 
 fn main()
 {
-    pkg_config::probe_library("libzfs_core").unwrap();
+    if cfg!(target_os = "freebsd") {
+        println!("cargo:rustc-link-lib=zfs_core");
+    } else {
+        pkg_config::probe_library("libzfs_core").unwrap();
+    }
+
     println!("cargo:rustc-link-lib=nvpair");
 }


### PR DESCRIPTION
libzfs_core ships in the FreeBSD base system and FreeBSD does not use pkg-config.