### PR TITLE
Skip building nvpair-sys on mac

### DIFF
--- a/nvpair-sys/build.rs
+++ b/nvpair-sys/build.rs
@@ -1,4 +1,7 @@
-fn main()
-{
+#[cfg(not(target_os = "macos"))]
+fn main() {
     println!("cargo:rustc-link-lib=nvpair");
 }
+
+#[cfg(target_os = "macos")]
+fn main() {}


### PR DESCRIPTION
When developing on a mac, we don't need to regenerate the bindings for
nvpair-sys. add a cfg attr to skip building on mac.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>