### PR TITLE
Add a way to access stored data

### DIFF
--- a/nvpair/src/lib.rs
+++ b/nvpair/src/lib.rs
@@ -1,14 +1,14 @@
-extern crate nvpair_sys as sys;
 extern crate cstr_argument;
+extern crate nvpair_sys as sys;
 #[macro_use]
 extern crate foreign_types;
 
 use cstr_argument::CStrArgument;
-use std::io;
-use std::ptr;
+use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use std::ffi;
+use std::io;
 use std::os::raw::c_int;
-use foreign_types::{Opaque, ForeignTypeRef, ForeignType};
+use std::ptr;
 
 pub enum NvData {
     Bool,
@@ -35,16 +35,17 @@ pub trait NvEncode {
 }
 
 impl NvEncode for bool {
-    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()>
-    {
+    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()> {
         let name = name.into_cstr();
         let v = unsafe {
-            sys::nvlist_add_boolean_value(nv.as_mut_ptr(), name.as_ref().as_ptr(),
+            sys::nvlist_add_boolean_value(
+                nv.as_mut_ptr(),
+                name.as_ref().as_ptr(),
                 if *self {
                     sys::boolean::B_TRUE
                 } else {
                     sys::boolean::B_FALSE
-                }
+                },
             )
         };
         if v != 0 {
@@ -56,12 +57,9 @@ impl NvEncode for bool {
 }
 
 impl NvEncode for u32 {
-    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()>
-    {
+    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()> {
         let name = name.into_cstr();
-        let v = unsafe {
-            sys::nvlist_add_uint32(nv.as_mut_ptr(), name.as_ref().as_ptr(), *self)
-        };
+        let v = unsafe { sys::nvlist_add_uint32(nv.as_mut_ptr(), name.as_ref().as_ptr(), *self) };
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
         } else {
@@ -71,8 +69,7 @@ impl NvEncode for u32 {
 }
 
 impl NvEncode for ffi::CStr {
-    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()>
-    {
+    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()> {
         let name = name.into_cstr();
         let v = unsafe {
             sys::nvlist_add_string(nv.as_mut_ptr(), name.as_ref().as_ptr(), self.as_ptr())
@@ -86,15 +83,18 @@ impl NvEncode for ffi::CStr {
 }
 
 impl NvEncode for NvListRef {
-    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()>
-    {
+    fn insert<S: CStrArgument>(&self, name: S, nv: &mut NvListRef) -> io::Result<()> {
         let name = name.into_cstr();
         let v = unsafe {
-            sys::nvlist_add_nvlist(nv.as_mut_ptr(), name.as_ref().as_ptr(), self.as_ptr() as *mut _)
+            sys::nvlist_add_nvlist(
+                nv.as_mut_ptr(),
+                name.as_ref().as_ptr(),
+                self.as_ptr() as *mut _,
+            )
         };
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
-            } else {
+        } else {
             Ok(())
         }
     }
@@ -102,14 +102,14 @@ impl NvEncode for NvListRef {
 
 pub enum NvEncoding {
     Native,
-    Xdr
+    Xdr,
 }
 
 impl NvEncoding {
     fn as_raw(&self) -> c_int {
         match self {
             &NvEncoding::Native => sys::NV_ENCODE_NATIVE,
-            &NvEncoding::Xdr => sys::NV_ENCODE_XDR
+            &NvEncoding::Xdr => sys::NV_ENCODE_XDR,
         }
     }
 }
@@ -134,20 +134,18 @@ impl NvList {
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
         } else {
-            Ok(unsafe { Self::from_ptr(n) }) 
+            Ok(unsafe { Self::from_ptr(n) })
         }
     }
 
     /// Create a new `NvList` with the `NV_UNIQUE_NAME` constraint
     pub fn new_unqiue_names() -> io::Result<Self> {
         let mut n = ptr::null_mut();
-        let v = unsafe {
-            sys::nvlist_alloc(&mut n, sys::NV_UNIQUE_NAME, 0)
-        };
+        let v = unsafe { sys::nvlist_alloc(&mut n, sys::NV_UNIQUE_NAME, 0) };
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
         } else {
-            Ok(unsafe { Self::from_ptr(n) }) 
+            Ok(unsafe { Self::from_ptr(n) })
         }
     }
 
@@ -169,32 +167,25 @@ impl Clone for NvList {
 }
 
 impl NvListRef {
-    pub unsafe fn from_mut_ptr<'a>(v: *mut sys::nvlist) -> &'a mut Self
-    {
+    pub unsafe fn from_mut_ptr<'a>(v: *mut sys::nvlist) -> &'a mut Self {
         std::mem::transmute::<*mut sys::nvlist, &mut Self>(v)
     }
 
-    pub unsafe fn from_ptr<'a>(v: *const sys::nvlist) -> &'a Self
-    {
+    pub unsafe fn from_ptr<'a>(v: *const sys::nvlist) -> &'a Self {
         std::mem::transmute::<*const sys::nvlist, &Self>(v)
     }
 
-    pub fn as_mut_ptr(&mut self) -> *mut sys::nvlist
-    {
+    pub fn as_mut_ptr(&mut self) -> *mut sys::nvlist {
         unsafe { std::mem::transmute::<&mut NvListRef, *mut sys::nvlist>(self) }
     }
 
-    pub fn as_ptr(&self) -> *const sys::nvlist
-    {
+    pub fn as_ptr(&self) -> *const sys::nvlist {
         unsafe { std::mem::transmute::<&NvListRef, *const sys::nvlist>(self) }
     }
 
-    pub fn encoded_size(&self, encoding: NvEncoding) -> io::Result<usize>
-    {
+    pub fn encoded_size(&self, encoding: NvEncoding) -> io::Result<usize> {
         let mut l = 0usize;
-        let v = unsafe {
-            sys::nvlist_size(self.as_ptr() as *mut _, &mut l, encoding.as_raw())
-        };
+        let v = unsafe { sys::nvlist_size(self.as_ptr() as *mut _, &mut l, encoding.as_raw()) };
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
         } else {
@@ -207,8 +198,7 @@ impl NvListRef {
         v != sys::boolean::B_FALSE
     }
 
-    pub fn add_boolean<S: CStrArgument>(&mut self, name: S) -> io::Result<()>
-    {
+    pub fn add_boolean<S: CStrArgument>(&mut self, name: S) -> io::Result<()> {
         let name = name.into_cstr();
         let v = unsafe { sys::nvlist_add_boolean(self.as_mut_ptr(), name.as_ref().as_ptr()) };
         if v != 0 {
@@ -219,7 +209,7 @@ impl NvListRef {
     }
 
     pub fn first(&self) -> Option<&NvPair> {
-        let np = unsafe { sys::nvlist_next_nvpair(self.as_ptr() as *mut _, ptr::null_mut()) };  
+        let np = unsafe { sys::nvlist_next_nvpair(self.as_ptr() as *mut _, ptr::null_mut()) };
         if np.is_null() {
             None
         } else {
@@ -234,14 +224,13 @@ impl NvListRef {
         }
     }
 
-    pub fn exists<S: CStrArgument>(&self, name: S) -> bool
-    {
+    pub fn exists<S: CStrArgument>(&self, name: S) -> bool {
         let name = name.into_cstr();
         let v = unsafe { sys::nvlist_exists(self.as_ptr() as *mut _, name.as_ref().as_ptr()) };
         v != sys::boolean::B_FALSE
     }
 
-    /* 
+    /*
     // not allowed because `pair` is borrowed from `self`. Need to fiddle around so that we can
     // check:
     //  - `pair` is from `self`
@@ -257,11 +246,12 @@ impl NvListRef {
     }
     */
 
-    pub fn lookup<S: CStrArgument>(&self, name: S) -> io::Result<&NvPair>
-    {
+    pub fn lookup<S: CStrArgument>(&self, name: S) -> io::Result<&NvPair> {
         let name = name.into_cstr();
         let mut n = ptr::null_mut();
-        let v = unsafe { sys::nvlist_lookup_nvpair(self.as_ptr() as *mut _, name.as_ref().as_ptr(), &mut n) };
+        let v = unsafe {
+            sys::nvlist_lookup_nvpair(self.as_ptr() as *mut _, name.as_ref().as_ptr(), &mut n)
+        };
         if v != 0 {
             Err(io::Error::from_raw_os_error(v))
         } else {
@@ -282,14 +272,14 @@ impl NvListRef {
 
 pub struct NvListIter<'a> {
     parent: &'a NvListRef,
-    pos: *mut sys::nvpair, 
+    pos: *mut sys::nvpair,
 }
 
 impl<'a> Iterator for NvListIter<'a> {
     type Item = &'a NvPair;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let np = unsafe { sys::nvlist_next_nvpair(self.parent.as_ptr() as *mut _, self.pos) };  
+        let np = unsafe { sys::nvlist_next_nvpair(self.parent.as_ptr() as *mut _, self.pos) };
         self.pos = np;
         if np.is_null() {
             None
@@ -305,8 +295,7 @@ impl ForeignTypeRef for NvPair {
 }
 
 impl NvPair {
-    pub fn name(&self) -> &ffi::CStr
-    {
+    pub fn name(&self) -> &ffi::CStr {
         unsafe { ffi::CStr::from_ptr(sys::nvpair_name(self.as_ptr())) }
     }
 }

--- a/nvpair/src/lib.rs
+++ b/nvpair/src/lib.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::os::raw::c_int;
 use std::ptr;
 
+#[derive(Debug)]
 pub enum NvData<'a> {
     Unknown,
     Bool,
@@ -271,6 +272,17 @@ impl NvListRef {
     }
 }
 
+impl std::fmt::Debug for NvListRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_map()
+            .entries(
+                self.iter()
+                    .map(|&ref pair| (pair.name().to_owned().into_string().unwrap(), pair.data())),
+            )
+            .finish()
+    }
+}
+
 pub struct NvListIter<'a> {
     parent: &'a NvListRef,
     pos: *mut sys::nvpair,
@@ -417,6 +429,15 @@ impl NvPair {
             }
             _ => NvData::Unknown,
         }
+    }
+}
+
+impl std::fmt::Debug for NvPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_tuple("NvPair")
+            .field(&self.name())
+            .field(&self.data())
+            .finish()
     }
 }
 

--- a/nvpair/tests/nvpair.rs
+++ b/nvpair/tests/nvpair.rs
@@ -69,6 +69,26 @@ fn insert() {
 
     let _b1 = a.lookup("bool1").expect("lookup of bool1 failed");
 
+    match _b1.data() {
+        nvpair::NvData::BoolV(v) => {
+            assert!(v == true);
+        }
+        _ => {
+            panic!("Unexpected type");
+        }
+    }
+
+    let _u1 = a.lookup("u32").expect("lookup of u32 failed");
+
+    match _u1.data() {
+        nvpair::NvData::Uint32(v) => {
+            assert!(v == 6u32);
+        }
+        _ => {
+            panic!("Unexpected type");
+        }
+    }
+
     //a.remove(&b1).expect("remove of b1 failed");
 
     // FIXME: use option wrapper


### PR DESCRIPTION
This pull-request adds functions to access the data contained inside the nvpair. 

The previously unused NvData structure is used and filled by the `.data()` method on `NvPair`. Helper methods `.as_str()`, `.as_string()` and `.as_list()` have been added for ease of use.

Using these new `.data()` the `std::fmt::Debug` has been implemented to allow easy dumping of the data.