### PR TITLE
Conditionally link libspl and zutil on FreeBSD

### DIFF
--- a/nvpair-sys/build.rs
+++ b/nvpair-sys/build.rs
@@ -3,4 +3,8 @@ fn main() {
     // FIXME: a bug exists in some versions of libnvpair causing it to depend on a symbol called
     // `aok`, which is in `libzfs`.
     println!("cargo:rustc-link-lib=zfs");
+    // nvpair uses functions from libspl on FreeBSD
+    if cfg!(target_os="freebsd") {
+      println!("cargo:rustc-link-lib=spl");
+    };
 }

--- a/nvpair-sys/build.rs
+++ b/nvpair-sys/build.rs
@@ -4,7 +4,7 @@ fn main() {
     // `aok`, which is in `libzfs`.
     println!("cargo:rustc-link-lib=zfs");
     // nvpair uses functions from libspl on FreeBSD
-    if cfg!(target_os="freebsd") {
-      println!("cargo:rustc-link-lib=spl");
+    if cfg!(target_os = "freebsd") {
+        println!("cargo:rustc-link-lib=spl");
     };
 }

--- a/zfs-core-sys/build.rs
+++ b/zfs-core-sys/build.rs
@@ -8,4 +8,7 @@ fn main() {
     }
 
     println!("cargo:rustc-link-lib=nvpair");
+    if cfg!(target_os="freebsd") {
+      println!("cargo:rustc-link-lib=zutil");
+    };
 }

--- a/zfs-core-sys/build.rs
+++ b/zfs-core-sys/build.rs
@@ -8,7 +8,7 @@ fn main() {
     }
 
     println!("cargo:rustc-link-lib=nvpair");
-    if cfg!(target_os="freebsd") {
-      println!("cargo:rustc-link-lib=zutil");
+    if cfg!(target_os = "freebsd") {
+        println!("cargo:rustc-link-lib=zutil");
     };
 }


### PR DESCRIPTION
FreeBSD's version of `libnvpair` uses functions (for example `libspl_assertf`) from `libspl`. Right now build is broken on FreeBSD due to this.

`libzfs_core` depends `libzutil` that holds a shim for `zfs_ioctl_fd` function.

Error in question:

```
   Compiling nvpair-sys v0.4.0 (/usr/home/andoriyu/rust-libzfs/nvpair-sys)
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-Wl,--eh-frame-hdr" "-L" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.1fspym4vx839le7u.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.1kpmeduvbomt860u.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.2dc0lftqfmb92asf.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.2j13m67krmezibkk.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.2lxj8z2t6i242zfb.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.4gx1tne5eh8pz0ms.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.4mvchp1wcaaer2tt.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.595xf4hg1eph114a.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.59j3v6hdsmtrjjn3.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.5c2m9lqpx77e4ia8.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.5fiwe119pvarbdjz.rcgu.o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.l6q8u4qlad0ktl.rcgu.o" "-o" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379" "/usr/home/andoriyu/rust-libzfs/target/debug/deps/nvpair_sys-ad5d16b4ad387379.1hdsdnooxdjenarh.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro" "-Wl,-znow" "-nodefaultlibs" "-L" "/usr/home/andoriyu/rust-libzfs/target/debug/deps" "-L" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib" "-lnvpair" "-lzfs" "-Wl,-Bstatic" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libtest-e4d8e27bba2fafe9.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libterm-fca7fddc86ed2a6e.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libgetopts-87ba50558c91e972.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libunicode_width-38a5366dda98a80a.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/librustc_std_workspace_std-b9e12c95cb61720b.rlib" "-Wl,--start-group" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libstd-3d778e71a3d2144e.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libpanic_unwind-01501494a9a2272f.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libminiz_oxide-f780d681cfa742d5.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libadler-c3fd082d3858d393.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libobject-09482ed94636277a.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libaddr2line-fbfea5310935424c.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libgimli-f5392f9b4b2d37a0.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/librustc_demangle-8a4a12e283f6bf35.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libhashbrown-9da1e161ce2fe917.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/librustc_std_workspace_alloc-25f1642cbffacef7.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libunwind-78301c711dd787ac.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libcfg_if-e0b4ed13ac3323ca.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/liblibc-b40818509f09fb0f.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/liballoc-dcd1311f0a05c03f.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/librustc_std_workspace_core-766670794099a124.rlib" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libcore-5f7d9add231d0df8.rlib" "-Wl,--end-group" "/usr/home/andoriyu/.rustup/toolchains/stable-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/libcompiler_builtins-84b862f5ffd396b9.rlib" "-Wl,-Bdynamic" "-lexecinfo" "-lpthread" "-lgcc_s" "-lc" "-lm" "-lrt" "-lpthread" "-lrt" "-lutil" "-lutil"
  = note: ld: error: /usr/lib/libnvpair.so: undefined reference to libspl_assertf [--no-allow-shlib-undefined]
          cc: error: linker command failed with exit code 1 (use -v to see invocation)

```