### PR TITLE
Fix linking to libzutil on FreeBSD

### DIFF
--- a/zfs-core-sys/build.rs
+++ b/zfs-core-sys/build.rs
@@ -9,6 +9,6 @@ fn main() {
 
     println!("cargo:rustc-link-lib=nvpair");
     if cfg!(target_os = "freebsd") {
-        println!("cargo:rustc-link-lib=zutil");
+        println!("cargo:rustc-link-lib=dylib:-as-needed=zutil");
     };
 }


### PR DESCRIPTION
Rust needs to use -as-needed when linking to transitive dependencies.
At least, on some targets.  It's undocumented which targets require
that.  This option is not documented in the Cargo Book, only in the RFC
Book:
https://rust-lang.github.io/rfcs/2951-native-link-modifiers.html

Fixes #65