### PR TITLE
remove native from cargo:rustc-link-lib

### DIFF
--- a/zfs-core-sys/build.rs
+++ b/zfs-core-sys/build.rs
@@ -97,7 +97,7 @@ fn main() {
             if let Some(v) = lzc_libdir {
                 println!("cargo:rustc-link-search=native={}", v.to_str().unwrap());
             }
-            println!("cargo:rustc-link-lib=native=zfs_core");
+            println!("cargo:rustc-link-lib=zfs_core");
         }
     }
 


### PR DESCRIPTION
`native` is only defined for `rustc-link-search`

https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib

Having it present in `rustc-link-lib` results in build errors.