### PR TITLE
NvList type is Send

### DIFF
--- a/nvpair/src/lib.rs
+++ b/nvpair/src/lib.rs
@@ -389,7 +389,7 @@ impl NvEncoding {
 
 foreign_type! {
     /// An `NvList`
-    pub unsafe type NvList {
+    pub unsafe type NvList: Send {
         type CType = sys::nvlist;
         fn drop = sys::nvlist_free;
     }


### PR DESCRIPTION
The NvList type can be safely sent to other threads.  Mark it as such by
implementing `Send`.

This is needed to use NvList's with async rust.  Let me know if I've misunderstood the semantics of `Send`.  It seems perfectly safe to operate on a `nvlist_t*` from a different thread, as long as it's only manipulated by one thread at a time.