### PR TITLE
gha/cadacy: use github action to submit coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -45,6 +45,8 @@ jobs:
       - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - run: bash <(curl -s https://codecov.io/bash) -f lcov.info
-      - run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r lcov.info
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: lcov.info


### PR DESCRIPTION
Was seeing some errors using the `get.sh` direct method for pushing codacy coverage info, try using the action instead