### PR TITLE
Workaround for missing libs on freebsd 13

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -42,7 +42,7 @@ jobs:
           RUSTFLAGS: '-Zinstrument-coverage'
           LLVM_PROFILE_FILE: 'rust-libzfs-%p-%m.profraw'
 
-      - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - run: bash <(curl -s https://codecov.io/bash) -f lcov.info
       - name: Run codacy-coverage-reporter

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -40,7 +40,7 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-      - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - run: zip -0 ccov.zip `find . \( -name "*.gc*" \) -print`
       - run: ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - name: Archive code coverage results

--- a/zfs-core-sys/build.rs
+++ b/zfs-core-sys/build.rs
@@ -114,5 +114,6 @@ fn main() {
     println!("cargo:rustc-link-lib=nvpair");
     if target_os == "freebsd" {
         println!("cargo:rustc-link-lib=dylib:-as-needed=zutil");
+        println!("cargo:rustc-link-lib=dylib:-as-needed=spl");
     }
 }


### PR DESCRIPTION
This pull request fixes linking issues on downstream libs on FreeBSD 13. See [libzetta-rs #166](https://github.com/Inner-Heaven/libzetta-rs/issues/166) for details.

I also updated the url for grcov binary so the workflows will run.

Hopefully this workaround can be removed once this [issue is fixed](https://github.com/Inner-Heaven/libzetta-rs/issues/166#issuecomment-1057534021) on FreeBSD side.